### PR TITLE
remove direct download from footer, incubating cleanup

### DIFF
--- a/_includes/news-list.html
+++ b/_includes/news-list.html
@@ -12,7 +12,7 @@
   {% if ctr < max %}
   {% assign ctr = ctr | plus:1 %}
   <p>
-    <a href="https://github.com/apache/incubator-druid/releases/tag/druid-{{ release.version }}">
+    <a href="https://github.com/apache/druid/releases/tag/druid-{{ release.version }}">
       <span class="title">Apache Druid {{ release.version | remove: "-incubating"}} Released</span><br>
       <span class="text-muted">{{ release.date | date: "%b %e %Y" }}</span>
     </a>

--- a/_includes/page_footer.html
+++ b/_includes/page_footer.html
@@ -15,8 +15,7 @@
   <div class="text-center">
     <a title="Join the user group" href="https://groups.google.com/forum/#!forum/druid-user" target="_blank"><span class="fa fa-comments"></span></a>&ensp;·&ensp;
     <a title="Follow Druid" href="https://twitter.com/druidio" target="_blank"><span class="fab fa-twitter"></span></a>&ensp;·&ensp;
-    <a title="Download via Apache" href="https://www.apache.org/dyn/closer.cgi?path=/incubator/druid/{{ site.druid_versions[0].versions[0].version }}/apache-druid-{{ site.druid_versions[0].versions[0].version }}-bin.tar.gz" target="_blank"><span class="fas fa-feather"></span></a>&ensp;·&ensp;
-    <a title="GitHub" href="https://github.com/apache/incubator-druid" target="_blank"><span class="fab fa-github"></span></a>
+    <a title="GitHub" href="https://github.com/apache/druid" target="_blank"><span class="fab fa-github"></span></a>
   </div>
   <div class="text-center license">
     Copyright © 2020 <a href="https://www.apache.org/" target="_blank">Apache Software Foundation</a>.<br>


### PR DESCRIPTION
Fixes https://github.com/apache/druid/issues/9264 by removing the link from the footer