### PR TITLE
Add reworked plugin Druid for Grafana

### DIFF
--- a/libraries.md
+++ b/libraries.md
@@ -69,6 +69,7 @@ UIs
 ---
 
 * [airbnb/superset](https://github.com/airbnb/superset) - A web application to slice, dice and visualize data out of Druid. Formerly Caravel and Panoramix
+* [Grafana](https://github.com/societe-generale/druidplugin) - A plugin for [Grafana](http://grafana.org/)
 * [grafana](https://github.com/Quantiply/grafana-plugins/tree/master/features/druid) - A plugin for [Grafana](http://grafana.org/)
 * [Pivot](https://github.com/implydata/pivot) - An exploratory analytics UI for Druid
 * [Metabase](https://github.com/metabase/metabase) - Simple dashboards, charts and query tool for your Druid DB


### PR DESCRIPTION
Societe General developpers worked on a connector Druid for Grafana and added features in order to work with the latest version of Grafana