### PR TITLE
Fix how to contribute doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,8 @@ By contributing to this repository you agree to license your contribution under 
 
 When submitting a pull request (PR), please use the following guidelines:
 
-- First verify your changes by running `bundle exec jekyll serve -w`.
-- For most webpage changes, please submit pull requests to this repository based off the "src" branch.
+- First verify your changes by [building & running](README.md#building) this
+- For most webpage changes, please submit pull requests to this repository
 - For any documentation changes (in the "docs" folder), please submit pull requests to the [main Druid
   repo](https://github.com/apache/druid-website-src). All Druid
   documentation is hosted under


### PR DESCRIPTION
I'm suspecting that the instruction to run `bundle exec jekyll serve -w` is outdated. Am I right?

Maybe it might work as well as `npm start` though, but I'm getting the same error with both commands.

Could you help me debug how to build this locally & then I can finish this PR?

I don't mind either if someone else fixes CONTRIBUTING.md, but I'm offering to do that as long as it makes sense to you as well.

----

I tried to build according to https://github.com/apache/druid-website-src#building but encountered some issues:

```
npm install
```

The command succeeds, but it prints these warnings:
```
added 131 packages, and audited 502 packages in 4s

27 vulnerabilities (8 low, 19 high)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details.
```

Is that ok?

```
bundle install
```

```
Using RedCloth 4.3.2
Using bundler 1.17.2
Using colorator 0.1
Using ffi 1.15.0
Using rb-fsevent 0.10.4
Using rb-inotify 0.10.1
Using sass-listen 4.0.0
Using sass 3.7.4
Using jekyll-sass-converter 1.5.2
Using listen 3.5.1
Using jekyll-watch 1.5.1
Using kramdown 1.17.0
Using liquid 3.0.6
Using mercenary 0.3.6
Using rouge 1.11.1
Using safe_yaml 1.0.5
Using jekyll 3.1.6
Using jekyll-textile-converter 0.1.0
Using pygments.rb 2.2.0
Using redcarpet 3.5.1
Bundle complete! 4 Gemfile dependencies, 20 gems now installed.
Bundled gems are installed into `./vendor/bundle`
```

Seems to succeed.

Note that I previously ran `bundle install --path vendor/bundle` – not sure if bundle remembers that, but I had some error previously when trying plain `bundle install`. I wonder how to test again from clean slate.. Would it be worth to add `--path vendor/bundle` in README?

Then:
```
gulp
```

Fails:

```
gulp failed because a require call failed with the error:
primordials is not defined
it is likely that running `npm install` will fix it.
```

And `npm install` doesn't seem to fix it for me.

Even though `gulp` failed already, trying the last step:

```
npm start
```

Fails:
```
> druid-website@0.2.0 start
> bundle exec jekyll serve --future --port 4001 --safe

Configuration file: /Users/juhoautio/ideaprojects/druid-website-src/_config.yml
            Source: /Users/juhoautio/ideaprojects/druid-website-src
       Destination: /Users/juhoautio/ideaprojects/druid-website-src/_site
 Incremental build: disabled. Enable with --incremental
      Generating...
             ERROR: YOUR SITE COULD NOT BE BUILT:
                    ------------------------------------
                    Invalid date '<%= Time.now.strftime('%Y-%m-%d %H:%M:%S %z') %>': Document 'vendor/bundle/ruby/2.6.0/gems/jekyll-3.1.6/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid date in the YAML front matter.
```