### PR TITLE
Add instructions on how to get druid slack channel invitation

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -20,15 +20,15 @@ issues, or contribute pull requests. If you're interested in development, please
 section below for details on our development process.
 * **Meetups:** Check out [Apache Druid on meetup.com](https://www.meetup.com/topics/apache-druid/) for links to regular
 meetups in cities all over the world.
-* **Slack:** Some committers and users are present in the channel `#druid` on the Apache Slack team. Please send an email to druid-user@googlegroups.com to get an invite to slack channel. You must send the request from same email-id that invite has to be sent to.
+* **Slack:** Many committers and users are present in the channel `#druid` on the Apache Slack team. Please send an email to druid-user@googlegroups.com to get an invite to slack channel. You must send the request from same email-id that slack invitation has to be sent to.
 * **Twitter:** Follow us on Twitter at [@druidio](https://twitter.com/druidio).
 * **StackOverflow:** While the user mailing list is the primary resource for asking questions, if you prefer
 StackOverflow, make sure to tag your question with `druid` or `apache-druid`.
 
 ## Getting help
 
-The best place to get a wide variety of help about Druid is on the Druid user
-group [druid-user@googlegroups.com](https://groups.google.com/forum/#!forum/druid-user). You can also report issues and problems, or suggest
+The best place to get a wide variety of help about Druid is via `#druid` on the Apache Slack team. There is also a druid user 
+google group [druid-user@googlegroups.com](https://groups.google.com/forum/#!forum/druid-user) however slack is the preferred way to get help. You can also report issues and problems, or suggest
 new features, on [GitHub](https://github.com/apache/druid).
 
 Third party companies also provide commercial support and services for Druid, including:

--- a/community/index.md
+++ b/community/index.md
@@ -20,8 +20,7 @@ issues, or contribute pull requests. If you're interested in development, please
 section below for details on our development process.
 * **Meetups:** Check out [Apache Druid on meetup.com](https://www.meetup.com/topics/apache-druid/) for links to regular
 meetups in cities all over the world.
-* **Slack:** Some committers and users are present in the channel `#druid` on the Apache Slack team. Please use our
-[invitation link to join](https://s.apache.org/slack-invite), and once you join, add the `#druid` channel.
+* **Slack:** Some committers and users are present in the channel `#druid` on the Apache Slack team. Please send an email to druid-user@googlegroups.com to get an invite to slack channel. You must send the request from same email-id that invite has to be sent to.
 * **Twitter:** Follow us on Twitter at [@druidio](https://twitter.com/druidio).
 * **StackOverflow:** While the user mailing list is the primary resource for asking questions, if you prefer
 StackOverflow, make sure to tag your question with `druid` or `apache-druid`.


### PR DESCRIPTION
Slack invite link for druid channel no longer works. Those without an `@apache.org` address need an invitation from someone who is already in the ASF slack workplace. 