### PR TITLE
Shift the invite link to point to Apache Druid Slack

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -21,7 +21,7 @@ issues, or contribute pull requests. If you're interested in development, please
 section below for details on our development process.
 * **Meetups:** Check out [Apache Druid on meetup.com](https://www.meetup.com/topics/apache-druid/) for links to regular
 meetups in cities all over the world.
-* **Slack:** Many committers and users are present in the channel `#druid` on the Apache Slack team. Please send an email to druid-user@googlegroups.com to get an invite to slack channel. You must send the request from same email-id that slack invitation has to be sent to.
+* **Slack:** Many users and committers are present on Apache Druid Slack. Use this link to join and invite others: [https://druid.apache.org/community/join-slack](/community/join-slack)
 * **Twitter:** Follow us on Twitter at [@druidio](https://twitter.com/druidio).
 * **StackOverflow:** While the user mailing list is the primary resource for asking questions, if you prefer
 StackOverflow, make sure to tag your question with `druid` or `apache-druid`.

--- a/community/join-slack.md
+++ b/community/join-slack.md
@@ -1,4 +1,4 @@
 ---
 layout: redirect_page
-redirect_target: https://s.apache.org/slack-invite
+redirect_target: https://join.slack.com/t/apache-pxf8668/shared_invite/zt-12ixypjv5-QPeGyL4qwwAdUYA7mz8H2Q
 ---


### PR DESCRIPTION
Update the universal `https://druid.apache.org/community/join-slack` invite link to point to the new Apache Druid Slack