### PR TITLE
Additional redirect to avoid caches

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -21,7 +21,7 @@ issues, or contribute pull requests. If you're interested in development, please
 section below for details on our development process.
 * **Meetups:** Check out [Apache Druid on meetup.com](https://www.meetup.com/topics/apache-druid/) for links to regular
 meetups in cities all over the world.
-* **Slack:** Many users and committers are present on Apache Druid Slack. Use this link to join and invite others: [https://druid.apache.org/community/join-slack](/community/join-slack)
+* **Slack:** Many users and committers are present on Apache Druid Slack. Use this link to join and invite others: [https://druid.apache.org/community/join-druid-slack](/community/join-druid-slack)
 * **Twitter:** Follow us on Twitter at [@druidio](https://twitter.com/druidio).
 * **StackOverflow:** While the user mailing list is the primary resource for asking questions, if you prefer
 StackOverflow, make sure to tag your question with `druid` or `apache-druid`.

--- a/community/join-druid-slack.md
+++ b/community/join-druid-slack.md
@@ -1,0 +1,4 @@
+---
+layout: redirect_page
+redirect_target: https://join.slack.com/t/apache-pxf8668/shared_invite/zt-12ixypjv5-QPeGyL4qwwAdUYA7mz8H2Q
+---


### PR DESCRIPTION
It appears some browsers / ISPs have interpreted the redirect as a 301, and theoretically this is why the redirect to the Slack invite is giving people the old Url.

As a safe reversible test of that theory, this change introduces a second redirect page (copy of the original) and changes the link on the community section `index.md`.