### PR TITLE
Disallow versioned docs post-24.0.

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -4,4 +4,13 @@
 
 User-agent: *
 Disallow: /docs/0*/
+Disallow: /docs/1*/
+Disallow: /docs/2*/
+Disallow: /docs/3*/
+Disallow: /docs/4*/
+Disallow: /docs/5*/
+Disallow: /docs/6*/
+Disallow: /docs/7*/
+Disallow: /docs/8*/
+Disallow: /docs/9*/
 


### PR DESCRIPTION
Versions don't necessarily start with zero anymore!

We need these directives so search engines prefer indexing the "latest" URLs instead of version-specific URLs.