### PR TITLE
Events - change to only show future events

### DIFF
--- a/_includes/event-list.html
+++ b/_includes/event-list.html
@@ -4,23 +4,42 @@
   <h3>
     Upcoming Events
   </h3>
-  {% for event in site.data.events limit: 7 %}
-  <div class="event">
-    <div class="mini-cal">
-      <div class="date-month">
-        {{ event.date | date: "%b" }}
+  {% assign event_count = 0 %}
+  {% assign event_count_max = 7 %}
+  {% assign today_date = "now" | date: '%s' | minus: 86400 | date: '%s' %}
+
+  {% for event in site.data.events %}
+
+    {% assign event_date = event.date | date: '%s' %}
+
+    {% if today_date < event_date %}
+
+    <div class="event">
+      <div class="mini-cal">
+        <div class="date-month">
+          {{ event.date | date: "%b" }}
+        </div>
+        <div class="date-day">
+          {{ event.date | date: "%e" }}
+        </div>
       </div>
-      <div class="date-day">
-        {{ event.date | date: "%e" }}
-      </div>
+      <p>
+        <a href="{{ event.link }}">
+          <span class ="title">{{ event.name }}</span><br>
+          <span class="text-muted">{{ event.info }}</span>
+        </a>
+      </p>
     </div>
-    <p>
-      <a href="{{ event.link }}">
-        <span class ="title">{{ event.name }}</span><br>
-        <span class="text-muted">{{ event.info }}</span>
-      </a>
-    </p>
-  </div>
+
+      {% assign event_count = event_count | plus: 1 %}
+
+    {% endif %}
+
+    {% if event_count == event_count_max %} {% break %} {% endif %}
+
   {% endfor %}
+
+  {% if event_count == 0 %} <p>Nothing scheduled yet.</p> {% endif %}
+
   <a class="btn btn-default btn-xs" href="https://www.meetup.com/topics/apache-druid/">Join a Druid Meetup!</a>
 </div>


### PR DESCRIPTION
Amends the iterator so that an event is only included if it's today or afterwards (bit of a hack without the time) - so only upcoming events are shown. Kicks out "nothing scheduled yet" if no events are relevant.