### PR TITLE
change the link to point to the actual latest docs

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -58,7 +58,7 @@ If you're looking for some starter projects, we maintain a [list of issues](http
 for new developers.
 
 There are plenty of ways to help outside writing Druid code. *Code review of pull requests*
-(even if you are not a committer), feature suggestions, reporting bugs, [documentation](/docs/{{ site.druid_stable_version }}/)
+(even if you are not a committer), feature suggestions, reporting bugs, [documentation](/docs/latest/design/)
 and usability feedback all matter immensely. Another big way to help is
 through [client libraries](/docs/latest/development/libraries.html), which are
 avaialble in a variety of languages. If you develop a new one, we'll be happy


### PR DESCRIPTION
The link on the rendered site ends up dropping people on the index for the whole site  since it resolves to `https://druid.apache.org/docs//`, which isn't that helpful IMO.

<img width="604" alt="image" src="https://user-images.githubusercontent.com/53799971/222278414-7eda191e-bb81-48c8-bbee-af5e823b7c11.png">

The intent of the logic seems to be to drop someone on the docs index page for most recent stable version, so it makes sense to replace it with `latest`.