### PR TITLE
Link to Druid-specific security page

### DIFF
--- a/_includes/page_header.html
+++ b/_includes/page_header.html
@@ -20,7 +20,7 @@
             <a href="https://www.apache.org/events/current-event" target="_blank">Events</a>
             <a href="https://www.apache.org/licenses/" target="_blank">License</a>
             <a href="https://www.apache.org/foundation/thanks.html" target="_blank">Thanks</a>
-            <a href="https://www.apache.org/security/" target="_blank">Security</a>
+            <a href="https://druid.apache.org/docs/latest/operations/security-overview.html" target="_blank">Security</a>
             <a href="https://www.apache.org/foundation/sponsorship.html" target="_blank">Sponsorship</a>
           </div>
         </li>


### PR DESCRIPTION
Make the 'Security' link on the homepage point to the Druid-specific security overview page, which contains relevant information about the Druid security trust model, and also contains the information on how to report security issues.