### PR TITLE
Link to Druid-specific security page

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -102,6 +102,13 @@ export default () => {
                   </p>
                 </div>
                 <div className="feature">
+                  <span className="fa fa-shield fa" />
+                  <h5> Security</h5>
+                  <p>
+                    Learn about <a href="/docs/latest/operations/security-overview.html">security features, configuration instructions, and best practices</a> to secure Druid.
+                  </p>
+                </div>
+                <div className="feature">
                   <span className="fa fa-question-circle fa" />
                   <h5> Get Help</h5>
                   <p>


### PR DESCRIPTION
Add a 'Security' link to the homepage pointing to the Druid-specific security overview page, which contains relevant information about the Druid security trust model, and also contains the information on how to report security issues. Remove the link to the generic Apache-wide security page, as that is linked from the Druid-specific one.