### PR TITLE
Add publishing option for updating site without docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ If you need to update the contents of Upcoming Events, Featured Content or Lates
 - `FeaturedContent.js` (rendered by `FeaturedContentWidget.js`)
 - `version.js` (rendered by `RecentReleasesWidget.js`)
 
+If you only need to update the homepage widgets,  use the `--no-docs` flag (as shown in example 5) to build the site. This uses the existing docs in `latest` and only builds `latest`, which is what's used for the homepage and other non-doc pages.
 
 ## Building the site for Druid 26 and later
 
@@ -51,28 +52,34 @@ These are the steps to publish either a new release or a hotfix to an existing r
 4. In `scripts`, run `python do_all_things.py -v VERSION`. The script assumes you used `npm` to install. See example 3 if you use `yarn`.
 
     **Example 1**: This command builds version 27.0.0 of the docs and latest.
+    
     ```
     python do_all_things.py -v 27.0.0
     ```
 
     **Example 2**: If you already have Docusaurus 2 installed, skip the installation by specifying the flag `--skip-install`.
+    
     ```
     python do_all_things.py -v 27.0.0 --skip-install
     ```
 
     **Example 3**: If you want to use yarn instead of npm, specify the flag `--yarn`.
+    
     ```
     python do_all_things.py -v 27.0.0 --yarn
     ```
 
     **Example 4**: If you have apache/druid in a completely different place (see note above), specify it using the `--source` flag.
+    
+
     ```
     python do_all_things.py -v 27.0.0 --source /my/path/to/apache/druid
     ```
 
-    **Example 5**: If you want to use the Markdown files already in this repo because you don't need to publish doc changes, use the `--no-docs` flag. The script will use the docs already in `docs/latest` to build the site. Use this if you need to republish the site to update the homepage widgets or other non-doc website pages.
+    **Example 5**: If you want to use the Markdown files already in this repo because you don't want to also publish doc changes, use the `--no-docs` flag. The script will use the docs already in `docs/latest` to build the site. Use this if you need to republish the site to update the homepage widgets or other non-doc website pages.
+    
     ```
-    python do_all_things.py -v 27.0.0 --no-docs
+    python do_all_things.py --no-docs
     ```
 
    For more information about the scripts, see [the scripts](#the-scripts).
@@ -83,7 +90,9 @@ These are the steps to publish either a new release or a hotfix to an existing r
 
 5. Go to `published_versions` and verify the site. If you run it locally, such as with `http-server` you'll get the latest version of the site, such as `localhost:8080/docs/latest/` and the version you built, such as `localhost:8080/docs/26.0.0/`. In addition, you should be able to see pre-Docusaurus2 versions such as 25.0.0 with the old CSS.
 
-6. Make a PR to `https://github.com/apache/druid-website` with the contents of `published_versions`.
+6. Commit the built files to `druid-website-src` and make a PR.
+
+7. Use the contents of `published_versions` to make a PR to `https://github.com/apache/druid-website` (either the `asf-staging` branch or the `asf-site` branch).
 
 ### The scripts
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ These are the steps to publish either a new release or a hotfix to an existing r
 
 5. Go to `published_versions` and verify the site. If you run it locally, such as with `http-server` you'll get the latest version of the site, such as `localhost:8080/docs/latest/` and the version you built, such as `localhost:8080/docs/26.0.0/`. In addition, you should be able to see pre-Docusaurus2 versions such as 25.0.0 with the old CSS.
 
-6. Commit the built files to `druid-website-src` and make a PR.
+6. Commit the built files along with the Markdown files to `druid-website-src` and make a PR.
 
 7. Use the contents of `published_versions` to make a PR to `https://github.com/apache/druid-website` (either the `asf-staging` branch or the `asf-site` branch).
 

--- a/README.md
+++ b/README.md
@@ -50,11 +50,30 @@ These are the steps to publish either a new release or a hotfix to an existing r
 
 4. In `scripts`, run `python do_all_things.py -v VERSION`. The script assumes you used `npm` to install. See example 3 if you use `yarn`.
 
-   **Example 1**: `python do_all_things.py -v 26.0.0`. This command builds version 26.0.0 of the docs and latest.
+    **Example 1**: This command builds version 27.0.0 of the docs and latest.
+    ```
+    python do_all_things.py -v 27.0.0
+    ```
 
-   **Example 2**: If you already have Docusaurus 2 installed, skip the installation by specifying the flag `--skip-install`. For example, `python do_all_things.py -v 26.0.0 --skip-install`
+    **Example 2**: If you already have Docusaurus 2 installed, skip the installation by specifying the flag `--skip-install`.
+    ```
+    python do_all_things.py -v 27.0.0 --skip-install
+    ```
 
-   **Example 3**: If you want to use yarn instead of npm, specify the flag `--yarn`. For example, `python do_all_things.py -v 26.0.0 --skip-install --yarn`
+    **Example 3**: If you want to use yarn instead of npm, specify the flag `--yarn`.
+    ```
+    python do_all_things.py -v 27.0.0 --yarn
+    ```
+
+    **Example 4**: If you have apache/druid in a completely different place (see note above), specify it using the `--source` flag.
+    ```
+    python do_all_things.py -v 27.0.0 --source /my/path/to/apache/druid
+    ```
+
+    **Example 5**: If you want to skip all the source docs (don't copy them from apache/druid), use the `--no-docs` flag.
+    ```
+    python do_all_things.py -v 27.0.0 --no-docs
+    ```
 
    For more information about the scripts, see [the scripts](#the-scripts).
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ These are the steps to publish either a new release or a hotfix to an existing r
     python do_all_things.py -v 27.0.0 --source /my/path/to/apache/druid
     ```
 
-    **Example 5**: If you want to skip all the source docs (don't copy them from apache/druid), use the `--no-docs` flag.
+    **Example 5**: If you want to use the Markdown files already in this repo because you don't need to publish doc changes, use the `--no-docs` flag. The script will use the docs already in `docs/latest` to build the site. Use this if you need to republish the site to update the homepage widgets or other non-doc website pages.
     ```
     python do_all_things.py -v 27.0.0 --no-docs
     ```

--- a/scripts/do_all_things.py
+++ b/scripts/do_all_things.py
@@ -6,13 +6,16 @@ import shutil
 
 def main(versions, no_docs, source, skip_install, use_yarn):
 
-    # if no_docs is True, don't copy docs over from source
-    # if False, copy the source Markdown files from apache/druid
+    # if we want to update docs, copy over from apache/druid
     if not no_docs:
         copy_druid_docs.main(versions, source)
 
-    # build all specified versions of the docs
-    build_docs.main([versions, "latest"], skip_install, use_yarn)
+        # build all specified versions of the docs
+        build_docs.main([versions, "latest"], skip_install, use_yarn)
+
+    # if we don't want to update docs, just build latest
+    else:
+        build_docs.main(["latest"], skip_install, use_yarn)
 
     print("Copying build output to ../published_versions. Use that directory to publish the site.")
     shutil.copytree('build','published_versions', dirs_exist_ok=True)
@@ -21,14 +24,14 @@ if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser()
 
-    parser.add_argument("-v", "--version", required=True,
+    parser.add_argument("-v", "--version",
                         help="Version to copy and build. Do not include 'latest'"
                         " since it's already accounted for. "
                         "For example: -v 26.0.0")
 
     parser.add_argument("--no-docs", default=False,
-                        help="Set this option if you want to update non-docs ",
-                        "pages, such as the home page."
+                        help="Set this option if you ONLY want to update "
+                        "non-docs pages, such as the home page.",
                         action='store_true')
 
     parser.add_argument("-s", "--source", default="../../druid",
@@ -43,6 +46,11 @@ if __name__ == "__main__":
                         action='store_true')
 
     args = parser.parse_args()
+
+    # you can only skip the --version flag if no-docs is True
+    # when no-docs is False, --version is required
+    if not args.no_docs and not args.version:
+        parser.error("--version is required when --no-docs is False")
 
     main(args.version, args.no_docs, args.source, args.skip_install, args.yarn)
 

--- a/scripts/do_all_things.py
+++ b/scripts/do_all_things.py
@@ -4,10 +4,12 @@ import shutil
 
 # Example: python do_all_things.py -v 26.0.0
 
-def main(versions, source, skip_install, use_yarn):
+def main(versions, no_docs, source, skip_install, use_yarn):
 
-    # copy the docs from apache/druid
-    copy_druid_docs.main(versions, source)
+    # if no_docs is True, don't copy docs over from source
+    # if False, copy the source Markdown files from apache/druid
+    if not no_docs:
+        copy_druid_docs.main(versions, source)
 
     # build all specified versions of the docs
     build_docs.main([versions, "latest"], skip_install, use_yarn)
@@ -24,6 +26,11 @@ if __name__ == "__main__":
                         " since it's already accounted for. "
                         "For example: -v 26.0.0")
 
+    parser.add_argument("--no-docs", default=False,
+                        help="Set this option if you want to update non-docs ",
+                        "pages, such as the home page."
+                        action='store_true')
+
     parser.add_argument("-s", "--source", default="../../druid",
                         help="The apache/druid folder to use as docs source.")
 
@@ -37,5 +44,5 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    main(args.version, args.source, args.skip_install, args.yarn)
+    main(args.version, args.no_docs, args.source, args.skip_install, args.yarn)
 


### PR DESCRIPTION
Use the `--no-docs` flag if you want to use the publish script to update the site (e.g., home page) without any change in the documentation

Example:
```
python do_all_things.py -v 27.0.0 --no-docs
```