### PR TITLE
Update Deep.BI Druid libraries and tools

### DIFF
--- a/src/pages/libraries.md
+++ b/src/pages/libraries.md
@@ -65,6 +65,14 @@ Some great folks have written their own libraries to interact with Apache Druid.
 
 * [bugzmanov/druid-io-rs](https://github.com/bugzmanov/druid-io-rs) - Fully asynchronous, future-enabled Apache Druid client library for rust programming language.
 
+External Druid data readers
+---------------------------
+Tools and libraries that allow to access and query Druid data (segments) directly.
+
+#### Spark
+
+* [deep-bi/spark-druid-segment-reader](https://github.com/deep-bi/spark-druid-segment-reader) - Apache Spark connector for Scala and Python APIs for reading Druid segments directly from the Deep Storage. It replaces the need for the scan queries as Spark can load any historical segments directly (e.g. for heavy queries or machine learning). 
+
 Other Druid Distributions
 -------------------------
 * [eBay/embedded-druid](https://github.com/eBay/embedded-druid) - Leveraging Druid capabilities in stand alone application
@@ -76,7 +84,7 @@ UIs
 ---
 
 * [Apache Superset](https://github.com/apache/superset) - Superset is a modern data exploration and data visualization platform.
-* [Deep.Explorer](https://www.deep.bi/solutions/apache-druid) - A UI built for slice & dice analytics, adhoc queries and powerful, easy data visualizations
+* [Deep.Explorer](https://www.deep.bi/apache-druid/tools#deep-explorer) - A UI built for slice & dice analytics, ad-hoc queries and powerful, easy data visualizations
 * [Grafana](https://github.com/societe-generale/druidplugin) - A plugin for [Grafana](http://grafana.org/)
 * [grafana](https://github.com/Quantiply/grafana-plugins/tree/master/features/druid) - A plugin for [Grafana](http://grafana.org/)
 * [Pivot](https://github.com/implydata/pivot) - An exploratory analytics UI for Druid


### PR DESCRIPTION
We would like to update the existing URL of our tool. The previous link is no longer pointing to the correct location.

We also wanted to include this PR https://github.com/apache/druid-website-src/pull/348 which is no longer valid as the `library.md` file location changed. 