### PR TITLE
Update build scripts to save assets for all versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,15 @@ Run `npm install` or `yarn install` in the root of the directory.
 
 These are the steps to publish either a new release or a hotfix to an existing release. Note that you'll always need to build `latest` so that the downloads page lists the correct versions, so the script automatically builds latest for you.
 
-> Note that the build scripts expect `apache/druid` and `apache/druid-website-src` to be peers at the same directory level.
+Before you start:
+* Make sure you're on the correct branch in your apache/druid repo.
+* Get the path of the apache/druid repo. You can skip this if you have `apache/druid` and `apache/druid-website-src` as peers at the same directory level.
 
 1. Update the version list in `static/js/version.js`. The highest release version goes in position 0. This file is used by `RecentReleasesWidget` on the home page to display the 3 most recent versions and to interpolate the download links on the download page.
 
 2. From the root of `druid-website-src`, go to `scripts/`.
 
-3. In `copy_druid_docs.py`, set `source_directory` to your OSS Druid repo. Make sure you're on the correct branch in your Druid repo before continuing. 
-
-4. In `scripts`, run `python do_all_things.py -v VERSION`. The script assumes you used `npm` to install. See example 3 if you use `yarn`.
+3. In `scripts`, run `python do_all_things.py -v VERSION`. The script assumes you used `npm` to install. See example 3 if you use `yarn`.
 
     **Example 1**: This command builds version 27.0.0 of the docs and latest.
     
@@ -69,8 +69,7 @@ These are the steps to publish either a new release or a hotfix to an existing r
     python do_all_things.py -v 27.0.0 --yarn
     ```
 
-    **Example 4**: If you have apache/druid in a completely different place (see note above), specify it using the `--source` flag.
-    
+    **Example 4**: If you have apache/druid in different place from druid-website-src, or use a different directory name than `druid`, specify its path using the `--source` flag.
 
     ```
     python do_all_things.py -v 27.0.0 --source /my/path/to/apache/druid
@@ -88,11 +87,11 @@ These are the steps to publish either a new release or a hotfix to an existing r
 
    The versions you built (such as 26.0.0 and latest) are copied to `published_versions` where the compiled pages for the older docs live.
 
-5. Go to `published_versions` and verify the site. If you run it locally, such as with `http-server` you'll get the latest version of the site, such as `localhost:8080/docs/latest/` and the version you built, such as `localhost:8080/docs/26.0.0/`. In addition, you should be able to see pre-Docusaurus2 versions such as 25.0.0 with the old CSS.
+4. Go to `published_versions` and verify the site. If you run it locally, such as with `http-server` you'll get the latest version of the site, such as `localhost:8080/docs/latest/` and the version you built, such as `localhost:8080/docs/26.0.0/`. In addition, you should be able to see pre-Docusaurus2 versions such as 25.0.0 with the old CSS.
 
-6. Commit the built files along with the Markdown files to `druid-website-src` and make a PR.
+5. Commit the built files along with the Markdown files to `druid-website-src` and make a PR.
 
-7. Use the contents of `published_versions` to make a PR to `https://github.com/apache/druid-website` (either the `asf-staging` branch or the `asf-site` branch).
+6. Use the contents of `published_versions` to make a PR to `https://github.com/apache/druid-website` (either the `asf-staging` branch or the `asf-site` branch).
 
 ### The scripts
 

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -4,11 +4,7 @@
 """
 build-docs.py
 
-<<<<<<< Updated upstream
-Version:        6 June 2023
-=======
 Version:        19 Oct 2023
->>>>>>> Stashed changes
 
 Purpose:        Build the OSS Druid Docusaurus 2 docs for all
                 versions supplied in the [-v, --versions] flag.
@@ -44,14 +40,10 @@ def build_docs(versions, use_yarn):
         replacement = f'var buildVersion = "{v}";'
         for line in fileinput.input("docusaurus.config.js", inplace=1):
             print(re.sub(r"^var buildVersion.*", replacement, line), end='')
-<<<<<<< Updated upstream
-        shutil.rmtree(f"published_versions/docs/{v}", ignore_errors=True) 
-=======
 
         # remove specific version folder in published_versions/docs if exists
         shutil.rmtree(f"published_versions/docs/{v}", ignore_errors=True)
 
->>>>>>> Stashed changes
         # build the docs
         if not use_yarn:
             subprocess.run(["npm", "run", "build"])
@@ -78,15 +70,12 @@ def build_docs(versions, use_yarn):
     shutil.rmtree(source_dir)
     shutil.move(destination_dir, source_dir)
 
-<<<<<<< Updated upstream
-=======
     # save the build output to check into GitHub
     # applies to last version only, typically "latest"
     print("Copying build output to ../published_versions. Use that directory to publish the site.")
     shutil.copytree('build','published_versions', dirs_exist_ok=True)
 
 
->>>>>>> Stashed changes
 def main(versions, skip_install, use_yarn):
 
     # from druid-website-src/static/build-scripts,
@@ -107,17 +96,11 @@ def main(versions, skip_install, use_yarn):
 
     # remove the old build directory
     shutil.rmtree('build', ignore_errors=True)
-<<<<<<< Updated upstream
-    # do the actual builds
-    build_docs(versions, use_yarn)
-
-=======
 
     # do the actual builds
     build_docs(versions, use_yarn)
 
 
->>>>>>> Stashed changes
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser()

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -4,7 +4,11 @@
 """
 build-docs.py
 
+<<<<<<< Updated upstream
 Version:        6 June 2023
+=======
+Version:        19 Oct 2023
+>>>>>>> Stashed changes
 
 Purpose:        Build the OSS Druid Docusaurus 2 docs for all
                 versions supplied in the [-v, --versions] flag.
@@ -40,7 +44,14 @@ def build_docs(versions, use_yarn):
         replacement = f'var buildVersion = "{v}";'
         for line in fileinput.input("docusaurus.config.js", inplace=1):
             print(re.sub(r"^var buildVersion.*", replacement, line), end='')
+<<<<<<< Updated upstream
         shutil.rmtree(f"published_versions/docs/{v}", ignore_errors=True) 
+=======
+
+        # remove specific version folder in published_versions/docs if exists
+        shutil.rmtree(f"published_versions/docs/{v}", ignore_errors=True)
+
+>>>>>>> Stashed changes
         # build the docs
         if not use_yarn:
             subprocess.run(["npm", "run", "build"])
@@ -67,6 +78,15 @@ def build_docs(versions, use_yarn):
     shutil.rmtree(source_dir)
     shutil.move(destination_dir, source_dir)
 
+<<<<<<< Updated upstream
+=======
+    # save the build output to check into GitHub
+    # applies to last version only, typically "latest"
+    print("Copying build output to ../published_versions. Use that directory to publish the site.")
+    shutil.copytree('build','published_versions', dirs_exist_ok=True)
+
+
+>>>>>>> Stashed changes
 def main(versions, skip_install, use_yarn):
 
     # from druid-website-src/static/build-scripts,
@@ -87,9 +107,17 @@ def main(versions, skip_install, use_yarn):
 
     # remove the old build directory
     shutil.rmtree('build', ignore_errors=True)
+<<<<<<< Updated upstream
     # do the actual builds
     build_docs(versions, use_yarn)
 
+=======
+
+    # do the actual builds
+    build_docs(versions, use_yarn)
+
+
+>>>>>>> Stashed changes
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser()

--- a/scripts/do_all_things.py
+++ b/scripts/do_all_things.py
@@ -1,9 +1,5 @@
 import copy_druid_docs
 import build_docs
-<<<<<<< Updated upstream
-import shutil
-=======
->>>>>>> Stashed changes
 
 # Example: python do_all_things.py -v 26.0.0
 
@@ -20,12 +16,6 @@ def main(versions, no_docs, source, skip_install, use_yarn):
     else:
         build_docs.main(["latest"], skip_install, use_yarn)
 
-<<<<<<< Updated upstream
-    print("Copying build output to ../published_versions. Use that directory to publish the site.")
-    shutil.copytree('build','published_versions', dirs_exist_ok=True)
-
-=======
->>>>>>> Stashed changes
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser()

--- a/scripts/do_all_things.py
+++ b/scripts/do_all_things.py
@@ -1,6 +1,9 @@
 import copy_druid_docs
 import build_docs
+<<<<<<< Updated upstream
 import shutil
+=======
+>>>>>>> Stashed changes
 
 # Example: python do_all_things.py -v 26.0.0
 
@@ -17,9 +20,12 @@ def main(versions, no_docs, source, skip_install, use_yarn):
     else:
         build_docs.main(["latest"], skip_install, use_yarn)
 
+<<<<<<< Updated upstream
     print("Copying build output to ../published_versions. Use that directory to publish the site.")
     shutil.copytree('build','published_versions', dirs_exist_ok=True)
 
+=======
+>>>>>>> Stashed changes
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
Docusaurus 2 assigns an alphanumeric string to all assets, unlike Docusaurus 1, which kept the filename as is. Example: https://druid.apache.org/assets/images/druid-architecture-c89f21addd50d76d07dbc3a730cd856f.png

That means we can't re-publish a previous version of the docs without having the associated assets. This PR updates the build script to save the assets for all versions built.

Tested locally with the following command:
```
python do_all_things.py -v 28.0.0 --source ../../druid-apache
```