### PR TITLE
Remove reference to Hadoop 3 download link

### DIFF
--- a/src/pages/downloads.mdx
+++ b/src/pages/downloads.mdx
@@ -23,9 +23,7 @@ import { Releases } from "../../static/js/version";
 <li>Release date: {Releases[0].date}</li>
 <li>Binary download: <a href={ `https://www.apache.org/dyn/closer.cgi?path=/druid/${Releases[0].version}/apache-druid-${Releases[0].version}-bin.tar.gz`}>apache-druid-{Releases[0].version}-bin.tar.gz</a> (<a href={ `https://www.apache.org/dist/druid/${Releases[0].version}/apache-druid-${Releases[0].version}-bin.tar.gz.sha512`}>sha512</a>, <a href={ `https://www.apache.org/dist/druid/${Releases[0].version}/apache-druid-${Releases[0].version}-bin.tar.gz.asc`}>pgp</a>)</li>
 <li>Source download: <a href={ `https://www.apache.org/dyn/closer.cgi?path=/druid/${Releases[0].version}/apache-druid-${Releases[0].version}-src.tar.gz`}>apache-druid-{Releases[0].version}-bin.tar.gz</a> (<a href={ `https://www.apache.org/dist/druid/${Releases[0].version}/apache-druid-${Releases[0].version}-src.tar.gz.sha512`}>sha512</a>, <a href={ `https://www.apache.org/dist/druid/${Releases[0].version}/apache-druid-${Releases[0].version}-src.tar.gz.asc`}>pgp</a>)</li>
-<li>Hadoop3 compatible artifacts (use these only if you use Hadoop3 with your Druid cluster):
-  <ul><li>Binary download: <a href={ `https://www.apache.org/dyn/closer.cgi?path=/druid/${Releases[0].version}/apache-druid-${Releases[0].version}-hadoop3-bin.tar.gz`}>apache-druid-{Releases[0].version}-bin.tar.gz</a> (<a href={ `https://www.apache.org/dist/druid/${Releases[0].version}/apache-druid-${Releases[0].version}-hadoop3-bin.tar.gz.sha512`}>sha512</a>, <a href={ `https://www.apache.org/dist/druid/${Releases[0].version}/apache-druid-${Releases[0].version}-hadoop3-bin.tar.gz.asc`}>pgp</a>)</li></ul>
-  </li>
+
 <li>Release notes: <a href={ `https://github.com/apache/druid/releases/tag/druid-${Releases[0].version}`}>{Releases[0].version}</a></li>
 </ul>
 


### PR DESCRIPTION
There is no separate Hadoop 3 build for the 27 release. 