### PR TITLE
Renew the public invite for Slack

### DIFF
--- a/src/pages/community/join-slack.md
+++ b/src/pages/community/join-slack.md
@@ -2,8 +2,8 @@
 title: Redirecting...
 ---
 <head>
-<script>window.location.replace("https://join.slack.com/t/apachedruidworkspace/shared_invite/zt-143m5afbr-4ebnAPJPaQfNOUu_g1MvSw")</script>
+<script>window.location.replace("https://join.slack.com/t/apachedruidworkspace/shared_invite/zt-2652557xj-PKSalIShaaWTNiMrTBBtWQ")</script>
 </head>
 
-<a href ="https://join.slack.com/t/apachedruidworkspace/shared_invite/zt-143m5afbr-4ebnAPJPaQfNOUu_g1MvSw">Click here if you're not redirected.</a>
+<a href ="https://join.slack.com/t/apachedruidworkspace/shared_invite/zt-2652557xj-PKSalIShaaWTNiMrTBBtWQ">Click here if you're not redirected.</a>
 


### PR DESCRIPTION
This expires after every 400 shares. When this happens, follow these instructions:

Anyone can currently create an invite link via:
Apache Druid -> Invite people to Apache Druid

However, the link has to be limited by either time and/or amount of people. Before pressing Copy invite link, first click on Edit link settings, where you can set the link expiry to "Never expire".

Then click the "Copy invite link" and use it to update the website.