### PR TITLE
Update releases widget

### DIFF
--- a/static/js/RecentReleasesWidget.js
+++ b/static/js/RecentReleasesWidget.js
@@ -31,7 +31,7 @@ export function RecentReleases({ data }) {
 }
 
 export  function RecentReleasesContainer({ jsonData }) {
-  const firstThree = jsonData.slice(0,5);
+  const firstThree = jsonData.slice(0,3);
   return (
     <div>
       {firstThree.map((data) => (

--- a/static/js/version.js
+++ b/static/js/version.js
@@ -24,9 +24,12 @@ Used by
  * limitations under the License.
  */
 
- 
 
 const Releases = [
+  {
+    version: "28.0.0",
+    date: "Nov 6 2023",
+  },
   {
     version: "27.0.0",
     date: "Aug 10 2023",
@@ -34,12 +37,7 @@ const Releases = [
   {
     version: "26.0.0",
     date: "May 23 2023",
-  },
-  {
-    version: "25.0.2",
-    date: "Jan 4 2023",
   }
+]
 
-  ]
-
-  module.exports.Releases = Releases;
+module.exports.Releases = Releases;


### PR DESCRIPTION
This PR changes the code in RecentReleasesWidget.js to show the three most recent releases. The PR also adds the Druid 28.0.0 release to the version.js file.

<img width="262" alt="Screen Shot 2023-11-15 at 1 46 44 PM" src="https://github.com/apache/druid-website-src/assets/38017980/b642c713-54fb-403e-9250-8edfc3807612">
