### PR TITLE
Fix release date for 30.0.0

### DIFF
--- a/static/js/version.js
+++ b/static/js/version.js
@@ -28,7 +28,7 @@ Used by
 const Releases = [
   {
     version: "30.0.0",
-    date: "Jun 17 2023",
+    date: "Jun 17 2024",
   },
   {
     version: "29.0.1",


### PR DESCRIPTION
Fixes the year (2023 > 2024) in the release date for Druid 30.0.0.