### PR TITLE
fix: change external img to just color in css

### DIFF
--- a/src/css/base.css
+++ b/src/css/base.css
@@ -293,7 +293,7 @@ html, body {
   text-align: center;
   color: white;
   overflow: hidden;
-  background-image: url('https://imply.io/wp-content/uploads/2023/09/ds23_background_stripe.png');
+  background-color: #10114B;
   background-size: cover;
   background-position: center;
   margin-bottom: 30px;


### PR DESCRIPTION
Apache infra does not like an external reference to an img, so the background doesn't show up on the staging site/prod site