### PR TITLE
infra: update copy druid script

### DIFF
--- a/scripts/copy_druid_docs.py
+++ b/scripts/copy_druid_docs.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import subprocess
+import re
 
 """
 copy_druid_docs.py does the following:
@@ -19,6 +20,7 @@ copy_druid_docs.py does the following:
 To use this as a standalone script, call it like:
 python copy_druid_docs.py -v 26.0.0
 """
+
 
 druid_variable = "{{DRUIDVERSION}}"
 
@@ -57,17 +59,17 @@ def check_source(source_directory):
 
 def replace_text_in_file(destination_directory, druid_version):
     """
-    Find/replace {{DRUIDVERSION}} with the actual version
+    Find/replace \{\{DRUIDVERSION}} and {{DRUIDVERSION]] with the actual version
     """
 
     with open(destination_directory, 'r') as file:
         file_content = file.read()
 
-    modified_content = file_content.replace(druid_variable, druid_version)
+    # Replace both patterns
+    modified_content = re.sub(r"\{\{DRUIDVERSION\}\}|\{\{DRUIDVERSION\]\]", druid_version, file_content)
 
     with open(destination_directory, 'w') as file:
         file.write(modified_content)
-
 def do_the_replace(file_path, druid_version):
     for item in os.listdir(file_path):
         item_path = os.path.join(file_path, item)

--- a/scripts/copy_druid_docs.py
+++ b/scripts/copy_druid_docs.py
@@ -65,7 +65,7 @@ def replace_text_in_file(destination_directory, druid_version):
         file_content = file.read()
 
 
-    pattern = r"(?:\{\{DRUIDVERSION\}\}|\\\{DRUIDVERSION\}\}?|\\\{\{DRUIDVERSION\}\})"
+    pattern = r"\{\{DRUIDVERSION\}\}|\{DRUIDVERSION\}"
     modified_content = re.sub(pattern, druid_version, file_content)
 
     with open(destination_directory, 'w') as file:

--- a/scripts/copy_druid_docs.py
+++ b/scripts/copy_druid_docs.py
@@ -59,17 +59,18 @@ def check_source(source_directory):
 
 def replace_text_in_file(destination_directory, druid_version):
     """
-    Find/replace \{\{DRUIDVERSION}} and {{DRUIDVERSION]] with the actual version
+    Find/replace "{{DRUIDVERSION}}", "\{DRUIDVERSION}", "\{{DRUIDVERSION}}", "\{DRUIDVERSION}}"
     """
-
     with open(destination_directory, 'r') as file:
         file_content = file.read()
 
-    # Replace both patterns
-    modified_content = re.sub(r"\{\{DRUIDVERSION\}\}|\{\{DRUIDVERSION\]\]", druid_version, file_content)
+
+    pattern = r"(?:\{\{DRUIDVERSION\}\}|\\\{DRUIDVERSION\}\}?|\\\{\{DRUIDVERSION\}\})"
+    modified_content = re.sub(pattern, druid_version, file_content)
 
     with open(destination_directory, 'w') as file:
         file.write(modified_content)
+
 def do_the_replace(file_path, druid_version):
     for item in os.listdir(file_path):
         item_path = os.path.join(file_path, item)

--- a/scripts/copy_druid_docs.py
+++ b/scripts/copy_druid_docs.py
@@ -59,13 +59,14 @@ def check_source(source_directory):
 
 def replace_text_in_file(destination_directory, druid_version):
     """
-    Find/replace "{{DRUIDVERSION}}", "\{DRUIDVERSION}", "\{{DRUIDVERSION}}", "\{DRUIDVERSION}}"
+    Find/replace actual Druid version for these placeholders
+    "{{DRUIDVERSION}}", "\{\{DRUIDVERSION}}", "\{DRUIDVERSION}", "\{{DRUIDVERSION}}", "\{DRUIDVERSION}}"
     """
     with open(destination_directory, 'r') as file:
         file_content = file.read()
 
 
-    pattern = r"\{\{DRUIDVERSION\}\}|\{DRUIDVERSION\}"
+    pattern = r"([\\{]*)DRUIDVERSION([\\}]*)"
     modified_content = re.sub(pattern, druid_version, file_content)
 
     with open(destination_directory, 'w') as file:


### PR DESCRIPTION
Docusaurus 3 uses MDXv3, which is much stricter.

The longstanding way we've done variables is to find/replace `{{DRUIDVERSION}}` in the Markdown files. It worked in 2 b/c 2 was less strict. 3 is stricter and picks them up as Javascript variables that are undefined. 

Instead of making people learn a new way to do variables, this updates the copy script so that an escaped version of `\{\{DRUIDVERSION}}` (and variations) also get find/replaced


We would have to do a find/replace anyway unless we set up the variables to match each other in `druid-website-src` and `druid`

To verify this, check out the Markdown cleanup branch in https://github.com/apache/druid/pull/17740 and run the copy script in `scripts`.

Then grep for `DRUIDVERSION` in the markdown files and maybe whatever version you set, eg 32.0.0

```
grep -ir 'DRUIDVERSION' ./docs
```

```
grep -ir '32.0.0' ./docs
```