### PR TITLE
Add rb-druid-indexer to /src/pages/libraries.md & fix broken link

### DIFF
--- a/src/pages/libraries.md
+++ b/src/pages/libraries.md
@@ -104,4 +104,4 @@ Add Your Software
 -----------------
 
 If you've written software that uses Druid and want it included on this page,
-[edit it on GitHub](https://github.com/apache/druid-website-src/blob/master/libraries.md) to create a pull request!
+[edit it on GitHub](https://github.com/apache/druid-website-src/blob/master/src/pages/libraries.md) to create a pull request!

--- a/src/pages/libraries.md
+++ b/src/pages/libraries.md
@@ -91,6 +91,7 @@ Tools
 * [housejester/druid-test-harness](https://github.com/housejester/druid-test-harness) - A set of scripts to simplify standing up some servers and seeing how things work
 * [spaghettifunk/druid-prometheus-exporter](https://github.com/spaghettifunk/druid-prometheus-exporter) - A HTTP service for collecting Druid metrics and exposing them as Prometheus metrics
 * [rovio-ingest](https://github.com/rovio/rovio-ingest) - An implementation of the DatasourceV2 interface of Apache Spark™ for writing Spark Datasets to Apache Druid™.
+* [rb-druid-indexer](https://github.com/redBorder/rb-druid-indexer) - redBorder cluster-compatible distributed service for automatically managing Druid supervisor task submissions and spec file configurations.
 
 Community Extensions
 --------------------


### PR DESCRIPTION
Hi Apache team,

At redBorder, we developed rb-druid-indexer as one of our internal services. The idea is to simplify indexing task submissions in distributed systems. rb-druid-indexer functions as a cluster-compatible service that manages indexing tasks. It also load-balances task submissions and deletions to the Druid router(s) and includes failover capabilities using ZooKeeper for coordination.

Currently, rb-druid-indexer supports multiple Kafka brokers, custom field dimensions, load balancing across Druid routers, excluded dimensions, and several other useful features. You can configure rb-druid-indexer using a YAML file like the example below:

```
zookeeper_servers:
  - "rb-malvarez1.node:2181"
  - "rb-malvarez3.node:2181"
  - "rb-malvarez2.node:2181"

tasks:
  - task_name: "rb_monitor"
    feed: "rb_monitor"
    spec: "rb_monitor"
    kafka_brokers:
      - "rb-malvarez1.node:9092"
      - "rb-malvarez3.node:9092"
      - "rb-malvarez2.node:9092"
 ```




