### PR TITLE
Update "Getting help" section.

### DIFF
--- a/src/pages/community/index.mdx
+++ b/src/pages/community/index.mdx
@@ -36,9 +36,9 @@ Similar to Linen, Struct archives Slack threads so that you can continue to acce
 
 ## Getting help
 
-The best place to get a wide variety of help about Druid is via `#druid` on the Apache Slack team. There is also a druid user 
-google group [druid-user@googlegroups.com](https://groups.google.com/forum/#!forum/druid-user) however slack is the preferred way to get help. You can also report issues and problems, or suggest
-new features, on [GitHub](https://github.com/apache/druid).
+The best place to get a wide variety of help about Druid is on Slack. Use this link to join and invite others: [https://druid.apache.org/community/join-slack](/community/join-slack?v=1).
+
+You can also report issues and problems, or suggest a new feature, on [GitHub](https://github.com/apache/druid).
 
 Third party companies also provide commercial support and services for Druid, including:
 


### PR DESCRIPTION
The "getting help" section referred to using Apache Slack, but we've since moved to a dedicated workspace.