### PR TITLE
Fix responsiveness of overview and features sections

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -191,16 +191,67 @@ code {
       min-width: 130px;
     }
   }
+
+  .druid-feature-container {
+    grid-template-columns: 1fr;
+  }
+
+  .features .feature {
+    padding-left: 0;
+  }
+
+  .features .feature .fa {
+    position: relative;
+    margin: 0 auto 12px;
+  }
+}
+
+@media (max-width: 840px) {
+  .grid-container {
+    grid-template-columns: 1fr;
+  }
+
+  .features .feature {
+    padding-left: 60px;
+  }
+
+  .features .feature .fa {
+    width: 44px;
+    height: 44px;
+    line-height: 44px;
+    font-size: 16px;
+  }
 }
 
 @media (min-width: 992px) {
   .card {
     min-height: 294px;
   }
+
+  .grid-container {
+    grid-template-columns: 1fr;
+    padding-right: 10px;
+    padding-left: 10px;
+  }
 }
 
-@media (min-width: 1200px) {
-  .card {
-    min-height: 230px;
+@media (min-width: 841px) {
+  .grid-container {
+    grid-template-columns: 3fr 1fr;
+  }
+}
+
+@media (max-width: 500px) {
+  .druid-feature-container {
+    grid-template-columns: 1fr;
+  }
+
+  .features .feature {
+    padding-left: 0;
+  }
+
+  .features .feature .fa {
+    position: relative;
+    margin: 0 auto 12px;
   }
 }


### PR DESCRIPTION
## Problem

- The Overview and Upcoming Events section was not responsive for smaller screens.
- Key Druid Features cards were not responsive for smaller screens.

## Changes

- Fixed the responsiveness of overview section and upcoming events sections.
- Fixed the druid features grid responsiveness for smaller screens.

## Screenshots
### Before
<img width="532" height="3130" alt="screencapture-druid-apache-org-2026-02-12-01_36_32" src="https://github.com/user-attachments/assets/3a230f79-e508-41cf-b776-7eff35832a3e" />

### After
|one|two|
|-------|-------|
|<img width="605" height="3498" alt="e6ea45c9-d9ee-4480-849e-fc1665a2be4f" src="https://github.com/user-attachments/assets/e08e93ad-9e10-482d-a17b-c6c520686223" />|<img width="605" height="2722" alt="1efb4699-02b1-4f3b-86b6-7812b0531519" src="https://github.com/user-attachments/assets/c8f1d926-ec6b-42c9-b0c5-66d762251d56" />|
