### PR TITLE
Update link for Druid MCP server in libraries.md

### DIFF
--- a/src/pages/libraries.md
+++ b/src/pages/libraries.md
@@ -93,7 +93,7 @@ Tools
 * [spaghettifunk/druid-prometheus-exporter](https://github.com/spaghettifunk/druid-prometheus-exporter) - A HTTP service for collecting Druid metrics and exposing them as Prometheus metrics
 * [rovio-ingest](https://github.com/rovio/rovio-ingest) - An implementation of the DatasourceV2 interface of Apache Spark™ for writing Spark Datasets to Apache Druid™.
 * [rb-druid-indexer](https://github.com/redBorder/rb-druid-indexer) - redBorder cluster-compatible distributed service for automatically managing Druid supervisor task submissions and spec file configurations.
-* [apache-druid-mcp-server](https://github.com/AnilPuram/apache-druid-mcp-server) - Model Context Protocol (MCP) server for Apache Druid that provides AI tools and clients with seamless access to query, manage, and interact with Druid datasources through standardized MCP tools.
+* [druid-mcp-server](https://github.com/iunera/druid-mcp-server) - A comprehensive Model Context Protocol (MCP) server for Apache Druid that provides extensive tools, resources, and prompts for managing and analyzing Druid clusters. (handles query, ingestion, basic security and druid-health)
 
 Community Extensions
 --------------------


### PR DESCRIPTION
Replace druid-mcp-server. 

Suggested MCP Server isn't updated since 11 month, has 5 commits and is written in python. 
https://github.com/iunera/druid-mcp-server is actively maintained, java and has a sophisticated feature set. 

